### PR TITLE
Fix wrong image name in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM driftphp:base
+FROM driftphp/base
 
 #
 # Apisearch installation


### PR DESCRIPTION
Found  that the image used  in the Dockerfile, https://hub.docker.com/r/driftphp/base is with wrong name.