### PR TITLE
Support Windows users with .sh postgre startup script \r auto-removal

### DIFF
--- a/Dockerfile-postgres-extended
+++ b/Dockerfile-postgres-extended
@@ -1,0 +1,9 @@
+FROM postgres:alpine
+
+# this is used to support windows users.
+
+# adds startup schema loader script
+ADD ./docker-compose/postgres-init.sh /docker-entrypoint-initdb.d/postgres-init.sh
+
+# remove trailing \r character from the script
+RUN dos2unix /docker-entrypoint-initdb.d/postgres-init.sh

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -3,15 +3,15 @@ version: '3'
 services:
 
   postgres:
-    image: "postgres:alpine"
+    build:
+      context: ..
+      dockerfile: Dockerfile-postgres-extended
     container_name: demo_postgres
     networks: [main]
     environment:
       POSTGRES_USER: root
       POSTGRES_PASSWORD: root
       POSTGRES_DB: demo
-    volumes:
-      - ./postgres-init.sh:/docker-entrypoint-initdb.d/postgres-init.sh
     ports:
       - "5432:5432"
 


### PR DESCRIPTION
Using docker-compose volumes to map .sh scripts into container leads to a "trailing \r problem" (script can't be executed) when running the container from a windows machine. This leads to a corrupt environment and problems for Windows users to run this demo.

Instead of using docker-compose volumes, A new Dockerfile created to extend the Postgres image in order to remove the trailing \r when adding this file into the container using `dos2unix` utility.