### PR TITLE
Use .SQL file instead of .sh file to initialize db data.

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: demo
     volumes:
-      - ./mysql-init.sh:/docker-entrypoint-initdb.d/mysql-init.sh
+      - ./mysql-init.sql:/docker-entrypoint-initdb.d/mysql-init.sql
     ports:
       - "3306:3306"
 

--- a/docker-compose/mysql-init.sh
+++ b/docker-compose/mysql-init.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-mysql -uroot -proot demo -e "create table key_value (id varchar(255) not null, value varchar(255) not null, constraint id_value_pk primary key (id));"

--- a/docker-compose/mysql-init.sql
+++ b/docker-compose/mysql-init.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE IF NOT EXISTS demo;
+CREATE TABLE IF NOT EXISTS demo.key_value (id varchar(255) not null, value varchar(255) not null, constraint id_value_pk primary key (id));


### PR DESCRIPTION
Changing the way of loading data into the DATABASE from .sh file to .sql file - The main reason to do that is because .sh files that exposed through docker-compose into the container can cause "trailing \r character" problem for windows users when they are being executed by the container. Therefore, instead of using a .sh file to initiate the data into the DB, we use a simple .SQL file that will be exposed to the db conainer, and will be executed by MySQL when loaded.