### PR TITLE
docker-compose error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM driftphp/base-php8
 WORKDIR /var/www
 
 #
-# Apisearch installation
+# Drift demo installation
 #
 COPY . .
 RUN composer install -n --prefer-dist --no-dev --ignore-platform-reqs && \

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -8,7 +8,6 @@ services:
     networks: [driftphp_demo_main]
     command: --default-authentication-plugin=mysql_native_password
     environment:
-      MYSQL_USER: root
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: demo
     volumes:
@@ -31,6 +30,7 @@ services:
       - "${SERVER_PORT}:8000"
     networks: [driftphp_demo_main]
     entrypoint: ["php", "balancer", "8000", "driftphp_server_1:8000", "driftphp_server_2:8000", "driftphp_server_3:8000"]
+    env_file: ../.env
 
   driftphp_demo_server_1:
     build: ..


### PR DESCRIPTION
Hi there ! I've been testing the demo project and I've had to make some changes to make it work:

There are some incompatibilities with the current version of docker mysql image on the docker-compose.yml. When run composer up the console outputs something like this:
```
    driftphp_demo_mysql            | 2021-04-10 07:06:13+00:00 [ERROR] [Entrypoint]: MYSQL_USER="root", MYSQL_USER and MYSQL_PASSWORD are for configuring a regular user and cannot be used for the root user
    driftphp_demo_mysql            |     Remove MYSQL_USER="root" and use one of the following to control the root user password:
    driftphp_demo_mysql            |     - MYSQL_ROOT_PASSWORD
    driftphp_demo_mysql            |     - MYSQL_ALLOW_EMPTY_PASSWORD
    driftphp_demo_mysql            |     - MYSQL_RANDOM_ROOT_PASSWORD
    driftphp_demo_mysql exited with code 1
```
I've had to remove the MYSQL_USER variable for it to work. Note that you may need to delete the current container if you want to reproduce it.

    docker-compose -f docker-compose/docker-compose.yml rm -a -f
    
Add this command to docker-compose-build.sh script might be a good idea.

On the other hand, a definition of env_file is missing in driftphp_demo_tiny balancer, however I have not been able to make it work with my current version of docker-compose, I have needed to put the .env file in the docker-compose directory:

```
# docker -v
Docker version 20.10.5, build 55c4c88
# docker-compose -v
docker-compose version 1.29.0, build 07737305
```

Thanks to the team for the fantastic work.

Cheers